### PR TITLE
Paul test revert functionality in nightwatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 /scripts/sync-up
 /tests/reports
 /screenshots/
+.*.sw*

--- a/app.js
+++ b/app.js
@@ -42,6 +42,12 @@ function run(config, ready) {
           perLocale: true
         },
 
+        'products' : {
+          extend: 'apostrophe-pieces',
+          name: 'product',
+          label: 'Product',
+        },
+
         'apostrophe-templates': { viewsFolderFallback: __dirname + '/views' },
         'apostrophe-express': {
           session: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dump": "mongodump -d apostrophe-enterprise-testbed",
     "restore": "mongorestore --noIndexRestore mongodump/ --drop",
     "e2e-local": "nightwatch tests/scenarios/* --config nightwatch.js --env local",
-    "revert-local": "node_modules/.bin/nightwatch --config nightwatch.js --env local tests/scenarios/article.spec.js",
+   "revert-local": "node_modules/.bin/nightwatch --config nightwatch.js --env local tests/scenarios/revert.spec.js",
     "e2e-remote": "nightwatch tests/scenarios/* --config nightwatch.js --env remote",
     "test": "npm run e2e-remote"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dump": "mongodump -d apostrophe-enterprise-testbed",
     "restore": "mongorestore --noIndexRestore mongodump/ --drop",
     "e2e-local": "nightwatch tests/scenarios/* --config nightwatch.js --env local",
-    "article-local": "node_modules/.bin/nightwatch --config nightwatch.js --env local tests/scenarios/article.spec.js",
+    "revert-local": "node_modules/.bin/nightwatch --config nightwatch.js --env local tests/scenarios/article.spec.js",
     "e2e-remote": "nightwatch tests/scenarios/* --config nightwatch.js --env remote",
     "test": "npm run e2e-remote"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dump": "mongodump -d apostrophe-enterprise-testbed",
     "restore": "mongorestore --noIndexRestore mongodump/ --drop",
     "e2e-local": "nightwatch tests/scenarios/* --config nightwatch.js --env local",
+    "article-local": "node_modules/.bin/nightwatch --config nightwatch.js --env local tests/scenarios/article.spec.js",
     "e2e-remote": "nightwatch tests/scenarios/* --config nightwatch.js --env remote",
     "test": "npm run e2e-remote"
   },

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -47,12 +47,14 @@ module.exports = Object.assign(
       client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(manageTableRowSelector, () => {
-        client.pause(1200);
-        client.click(editArticleBtnSelector);
-        client.waitForElementVisible(editModalSelector);
-        client.clearValue(editTitleField);
-        client.setValue(editTitleField, 'Article Title 1');
-        client.click(saveBtnSelector);
+      client.pause(1200);
+      client.click(editArticleBtnSelector);
+      client.waitForElementVisible(editModalSelector);
+      client.clearValue(editTitleField);
+      client.setValue(editTitleField, 'Article Title 1');
+      client.click(saveBtnSelector);
+      client.waitForElementVisible(modalBlogSelector);
+      client.click(editArticleBtnSelector);
         client.pause()
       });
       //client.waitForElementVisible(controlSelector);

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -21,116 +21,104 @@ module.exports = Object.assign(
   steps.switchLocale('en'),
   steps.switchToDraftMode(),
   steps.createArticle('New Article Title'),
-  steps.workflowSubmitArticle(),
-  steps.checkNotification('Your submission will be reviewed.'),
-  steps.workflowCommitArticle(),
-  steps.checkNotification('New Article Title was committed successfully.'),
   {
-    "change title and commit": (client) => {
-      const modalExportSelector = '.apos-workflow-export-modal';
-      const exportSkipSelector = `${modalExportSelector} [data-apos-cancel]`;
+    'submit the article, via the "Workflow" menu in the dialog box': (client) => {
       const modalBlogSelector = '.apostrophe-blog-manager';
       const modalEditArticleSelector = '.apos-pieces-editor';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
       const editArticleBtnSelector = `${manageTableRowSelector} a`;
+      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
       const workflowModalBtnSelector =
         `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
       const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
-      const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
-      const editTitleField = `${editModalSelector} input[name=title]`;
-      const saveBtnSelector = '[data-apos-save]';
-      const commitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-commit]`;
-      const noPreviewSelector = '.apos-workflow-no-preview';
-      const notificationSelector = '.apos-notification-message';
-      const modalCommitSelector = '.apos-workflow-commit-modal';
-      const aposCommitBtnSelector = `${modalCommitSelector} [data-apos-save]`;
-      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
 
-      // bail out from last commit's export window
-      client.waitForElementVisible(exportSkipSelector);
-      client.click(exportSkipSelector);
-
-      // edit article and update title
-      client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(manageTableRowSelector);
       client.click(editArticleBtnSelector);
-      client.waitForElementVisible(editModalSelector);
-      client.clearValue(editTitleField);
-      client.setValue(editTitleField, 'Article Title 1');
-      client.click(saveBtnSelector);
-      client.waitForElementVisible(modalBlogSelector);
-      client.waitForElementVisible(editModalSelector);
-      client.waitForElementNotPresent(notificationSelector);
-
-      // commit the updated article
-      client.click(editArticleBtnSelector);
       client.waitForElementVisible(modalEditArticleSelector);
+      client.waitForElementVisible(controlSelector);
+      client.pause(1000);
       client.click(workflowModalBtnSelector);
-      client.waitForElementVisible(commitWorkflowBtnSelector);
-      client.click(commitWorkflowBtnSelector);
-      client.waitForElementVisible(noPreviewSelector);
-      client.expect.element(noPreviewSelector).text.to.equal('No preview available.');
-      client.waitForElementVisible(aposCommitBtnSelector);
-      client.click(aposCommitBtnSelector);
-      client.waitForElementVisible(modalExportSelector);
-      client.waitForElementVisible(exportSkipSelector);
-      client.click(exportSkipSelector);
-      client.waitForElementNotPresent(notificationSelector);
-      // TODO assert title = Artile Title 1
+      client.useCss();
+      client.waitForElementVisible(submitWorkflowBtnSelector);
+      client.click(submitWorkflowBtnSelector);
+      client.waitForElementNotPresent(modalEditArticleSelector);
     }
   },
+  steps.checkNotification('Your submission will be reviewed.'),
   {
-    'article can be found under "Articles" in draft mode with new title': (client) => {
-      const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
-      const modalBlogSelector = '.apostrophe-blog-manager';
-      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
-      client.keys(client.Keys.ESCAPE);
-      client.click(blogButtonSelector);
-      client.waitForElementVisible(modalBlogSelector);
-
-      client.expect.element(manageTableRowSelector).text.to.contain('Article Title 1');
-      client.expect.element(manageTableRowSelector).text.to.contain('Published');
-    }
-  },
-  {
-    'revert to initial version': (client) => {
-      const modalExportSelector = '.apos-workflow-export-modal';
+    'reopen the article. Commit the article.': (client) => {
       const modalBlogSelector = '.apostrophe-blog-manager';
       const modalEditArticleSelector = '.apos-pieces-editor';
+      const modalCommitSelector = '.apos-workflow-commit-modal';
+      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
       const editArticleBtnSelector = `${manageTableRowSelector} a`;
       const workflowModalBtnSelector =
         `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
-      const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
-      const notificationSelector = '.apos-notification-container';
-      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
-      // now revert to previous version
-      client.waitForElementNotPresent(modalExportSelector);
+      const commitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-commit]`;
+      const noPreviewSelector = '.apos-workflow-no-preview';
+      const saveBtnSelector = `${modalCommitSelector} [data-apos-save]`;
+      const notificationSelector = '.apos-notification-message';
+
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(manageTableRowSelector);
       client.click(editArticleBtnSelector);
       client.waitForElementVisible(modalEditArticleSelector);
+      client.waitForElementVisible(controlSelector);
+      client.pause(200);
       client.click(workflowModalBtnSelector);
-      client.waitForElementVisible(workflowHistoryBtnSelector);
-      client.click(workflowHistoryBtnSelector);
-      client.waitForElementVisible('.apos-manage-table');
-      client.waitForElementVisible('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
-      // TODO assert there are two rows
-      client.click('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
-      client.waitForNotElementVisible(notificationSelector);
+      client.useCss();
+      client.waitForElementVisible(commitWorkflowBtnSelector);
+      client.click(commitWorkflowBtnSelector);
+      client.waitForElementVisible(noPreviewSelector);
+
+      client.expect.element(noPreviewSelector).text.to.equal('No preview available.');
+
+      client.waitForElementNotPresent(notificationSelector);
+      client.click(saveBtnSelector);
     }
   },
+  steps.checkNotification('New Article Title was committed successfully.'),
   {
-    'article can be found under "Articles" in draft mode with new title': (client) => {
+    'export the article to all other locales.': (client) => {
+      const modalExportSelector = '.apos-workflow-export-modal';
+      const exportBtnSelector = `${modalExportSelector} [data-apos-save]`;
+      const masterLocaleBtnSelector = '[for*=master] span';
+      const notificationSelector = '.apos-notification-container';
+
+      client.waitForElementVisible(modalExportSelector);
+      client.waitForElementVisible(masterLocaleBtnSelector);
+      client.click(masterLocaleBtnSelector);
+      client.click(notificationSelector);
+      client.click(exportBtnSelector);
+      client.waitForElementNotPresent(modalExportSelector);
+    }
+  },
+  steps.checkNotification('Successfully exported to: master, fr, es'),
+  {
+    'close export dialog': (client) => {
+      const finishBtnSelector = '[data-apos-cancel]';
+      const blackoutSelector = '.apos-modal-blackout';
+
+      client.waitForElementVisible(finishBtnSelector);
+      client.pause(1000);
+      client.click(finishBtnSelector);
+      client.waitForElementNotPresent(blackoutSelector);
+    },
+  },
+  steps.switchLocale('es'),
+  steps.openAdminBar(),
+  {
+    'article can be found under "Articles" in draft mode for the es locale': (client) => {
       const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
       const modalBlogSelector = '.apostrophe-blog-manager';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
-      client.keys(client.Keys.ESCAPE);
-      client.pause(200);
-      client.waitForElementVisible(blogButtonSelector);
+
       client.click(blogButtonSelector);
+      client.useCss();
       client.waitForElementVisible(modalBlogSelector);
+
       client.expect.element(manageTableRowSelector).text.to.contain('New Article Title');
       client.expect.element(manageTableRowSelector).text.to.contain('Published');
     }

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -33,8 +33,6 @@ module.exports = Object.assign(
       const modalEditArticleSelector = '.apos-pieces-editor';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
       const editArticleBtnSelector = `${manageTableRowSelector} a`;
-
-      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
       const workflowModalBtnSelector =
         `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
       const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
@@ -79,8 +77,22 @@ module.exports = Object.assign(
       client.waitForElementVisible(modalExportSelector);
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
+      client.waitForElementNotPresent(notificationSelector);
       // TODO assert title = Artile Title 1
-
+    }
+  },
+  {
+    'revert to initial version': (client) => {
+      const modalExportSelector = '.apos-workflow-export-modal';
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const modalEditArticleSelector = '.apos-pieces-editor';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const editArticleBtnSelector = `${manageTableRowSelector} a`;
+      const workflowModalBtnSelector =
+        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
+      const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
+      const notificationSelector = '.apos-notification-container';
+      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
       // now revert to previous version
       client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
@@ -91,20 +103,19 @@ module.exports = Object.assign(
       client.waitForElementVisible(workflowHistoryBtnSelector);
       client.click(workflowHistoryBtnSelector);
       client.waitForElementVisible('.apos-manage-table');
+      client.waitForElementVisible('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
       // TODO assert there are two rows
       client.click('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
-
-      client.pause();
-
+      client.waitForElementVisible(notificationSelector);
     }
   },
+  steps.checkNotification('Document reverted to commit!'),
   {
     'export the article to all other locales.': (client) => {
       const modalExportSelector = '.apos-workflow-export-modal';
       const exportBtnSelector = `${modalExportSelector} [data-apos-save]`;
       const masterLocaleBtnSelector = '[for*=master] span';
       const notificationSelector = '.apos-notification-container';
-
       client.waitForElementVisible(modalExportSelector);
       client.waitForElementVisible(masterLocaleBtnSelector);
       client.click(masterLocaleBtnSelector);

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -33,22 +33,26 @@ module.exports = Object.assign(
       const modalEditArticleSelector = '.apos-pieces-editor';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
       const editArticleBtnSelector = `${manageTableRowSelector} a`;
+
       const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
       const workflowModalBtnSelector =
         `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
       const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
+      const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
+      const editTitleField = `${editModalSelector} input[name=title]`;
 
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
+      client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(manageTableRowSelector, () => {
-        console.log('visible')
         client.pause(1200);
         client.click(editArticleBtnSelector);
-        console.log('clicked')
+        client.waitForElementVisible(editModalSelector);
+        client.clearValue(editTitleField);
+        client.setValue(editTitleField, 'Article Title 1');
         client.pause()
       });
-      client.waitForElementVisible(modalEditArticleSelector);
       //client.waitForElementVisible(controlSelector);
     }
   },

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -70,7 +70,9 @@ module.exports = Object.assign(
       client.waitForElementVisible(aposCommitBtnSelector);
       client.pause(200);
       client.click(aposCommitBtnSelector);
-      client.pause();
+      client.waitForElementVisible(modalExportSelector);
+      client.waitForElementVisible(exportSkipSelector);
+      client.click(exportSkipSelector);
     }
   },
   {

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -21,65 +21,20 @@ module.exports = Object.assign(
   steps.switchLocale('en'),
   steps.switchToDraftMode(),
   steps.createArticle('New Article Title'),
-  {
-    'submit the article, via the "Workflow" menu in the dialog box': (client) => {
-      const modalBlogSelector = '.apostrophe-blog-manager';
-      const modalEditArticleSelector = '.apos-pieces-editor';
-      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
-      const editArticleBtnSelector = `${manageTableRowSelector} a`;
-      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
-      const workflowModalBtnSelector =
-        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
-      const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
-
-      client.waitForElementVisible(modalBlogSelector);
-      client.waitForElementVisible(manageTableRowSelector);
-      client.click(editArticleBtnSelector);
-      client.waitForElementVisible(modalEditArticleSelector);
-      client.waitForElementVisible(controlSelector);
-      client.pause(1000);
-      client.click(workflowModalBtnSelector);
-      client.useCss();
-      client.waitForElementVisible(submitWorkflowBtnSelector);
-      client.click(submitWorkflowBtnSelector);
-      client.waitForElementNotPresent(modalEditArticleSelector);
-    }
-  },
+  steps.workflowSubmitArticle(),
   steps.checkNotification('Your submission will be reviewed.'),
-  {
-    'reopen the article. Commit the article.': (client) => {
-      const modalBlogSelector = '.apostrophe-blog-manager';
-      const modalEditArticleSelector = '.apos-pieces-editor';
-      const modalCommitSelector = '.apos-workflow-commit-modal';
-      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
-      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
-      const editArticleBtnSelector = `${manageTableRowSelector} a`;
-      const workflowModalBtnSelector =
-        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
-      const commitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-commit]`;
-      const noPreviewSelector = '.apos-workflow-no-preview';
-      const saveBtnSelector = `${modalCommitSelector} [data-apos-save]`;
-      const notificationSelector = '.apos-notification-message';
-
-      client.waitForElementVisible(modalBlogSelector);
-      client.waitForElementVisible(manageTableRowSelector);
-      client.click(editArticleBtnSelector);
-      client.waitForElementVisible(modalEditArticleSelector);
-      client.waitForElementVisible(controlSelector);
-      client.pause(200);
-      client.click(workflowModalBtnSelector);
-      client.useCss();
-      client.waitForElementVisible(commitWorkflowBtnSelector);
-      client.click(commitWorkflowBtnSelector);
-      client.waitForElementVisible(noPreviewSelector);
-
-      client.expect.element(noPreviewSelector).text.to.equal('No preview available.');
-
-      client.waitForElementNotPresent(notificationSelector);
-      client.click(saveBtnSelector);
-    }
-  },
+  steps.workflowCommitArticle(),
   steps.checkNotification('New Article Title was committed successfully.'),
+  steps.pause(),
+
+  // new commit
+  // checknotification
+  // open history model
+  // select old commit
+  // press revert
+  // checknotification
+  // load article
+  // check that title matches commit
   {
     'export the article to all other locales.': (client) => {
       const modalExportSelector = '.apos-workflow-export-modal';

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -46,9 +46,13 @@ module.exports = Object.assign(
       const notificationSelector = '.apos-notification-message';
       const modalCommitSelector = '.apos-workflow-commit-modal';
       const aposCommitBtnSelector = `${modalCommitSelector} [data-apos-save]`;
+      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
 
+      // bail out from last commit's export window
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
+
+      // edit article and update title
       client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(manageTableRowSelector);
@@ -60,6 +64,8 @@ module.exports = Object.assign(
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(editModalSelector);
       client.waitForElementNotPresent(notificationSelector);
+
+      // commit the updated article
       client.click(editArticleBtnSelector);
       client.waitForElementVisible(modalEditArticleSelector);
       client.click(workflowModalBtnSelector);
@@ -73,6 +79,23 @@ module.exports = Object.assign(
       client.waitForElementVisible(modalExportSelector);
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
+      // TODO assert title = Artile Title 1
+
+      // now revert to previous version
+      client.waitForElementNotPresent(modalExportSelector);
+      client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(manageTableRowSelector);
+      client.click(editArticleBtnSelector);
+      client.waitForElementVisible(modalEditArticleSelector);
+      client.click(workflowModalBtnSelector);
+      client.waitForElementVisible(workflowHistoryBtnSelector);
+      client.click(workflowHistoryBtnSelector);
+      client.waitForElementVisible('.apos-manage-table');
+      // TODO assert there are two rows
+      client.click('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
+
+      client.pause();
+
     }
   },
   {

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -72,13 +72,25 @@ module.exports = Object.assign(
       client.waitForElementVisible(noPreviewSelector);
       client.expect.element(noPreviewSelector).text.to.equal('No preview available.');
       client.waitForElementVisible(aposCommitBtnSelector);
-      client.pause(200);
       client.click(aposCommitBtnSelector);
       client.waitForElementVisible(modalExportSelector);
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
       client.waitForElementNotPresent(notificationSelector);
       // TODO assert title = Artile Title 1
+    }
+  },
+  {
+    'article can be found under "Articles" in draft mode with new title': (client) => {
+      const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      client.keys(client.Keys.ESCAPE);
+      client.click(blogButtonSelector);
+      client.waitForElementVisible(modalBlogSelector);
+
+      client.expect.element(manageTableRowSelector).text.to.contain('Article Title 1');
+      client.expect.element(manageTableRowSelector).text.to.contain('Published');
     }
   },
   {
@@ -106,48 +118,19 @@ module.exports = Object.assign(
       client.waitForElementVisible('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
       // TODO assert there are two rows
       client.click('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
-      client.waitForElementVisible(notificationSelector);
+      client.waitForNotElementVisible(notificationSelector);
     }
   },
-  steps.checkNotification('Document reverted to commit!'),
   {
-    'export the article to all other locales.': (client) => {
-      const modalExportSelector = '.apos-workflow-export-modal';
-      const exportBtnSelector = `${modalExportSelector} [data-apos-save]`;
-      const masterLocaleBtnSelector = '[for*=master] span';
-      const notificationSelector = '.apos-notification-container';
-      client.waitForElementVisible(modalExportSelector);
-      client.waitForElementVisible(masterLocaleBtnSelector);
-      client.click(masterLocaleBtnSelector);
-      client.click(notificationSelector);
-      client.click(exportBtnSelector);
-      client.waitForElementNotPresent(modalExportSelector);
-    }
-  },
-  steps.checkNotification('Successfully exported to: master, fr, es'),
-  {
-    'close export dialog': (client) => {
-      const finishBtnSelector = '[data-apos-cancel]';
-      const blackoutSelector = '.apos-modal-blackout';
-
-      client.waitForElementVisible(finishBtnSelector);
-      client.pause(1000);
-      client.click(finishBtnSelector);
-      client.waitForElementNotPresent(blackoutSelector);
-    },
-  },
-  steps.switchLocale('es'),
-  steps.openAdminBar(),
-  {
-    'article can be found under "Articles" in draft mode for the es locale': (client) => {
+    'article can be found under "Articles" in draft mode with new title': (client) => {
       const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
       const modalBlogSelector = '.apostrophe-blog-manager';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
-
+      client.keys(client.Keys.ESCAPE);
+      client.pause(200);
+      client.waitForElementVisible(blogButtonSelector);
       client.click(blogButtonSelector);
-      client.useCss();
       client.waitForElementVisible(modalBlogSelector);
-
       client.expect.element(manageTableRowSelector).text.to.contain('New Article Title');
       client.expect.element(manageTableRowSelector).text.to.contain('Published');
     }

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -25,16 +25,33 @@ module.exports = Object.assign(
   steps.checkNotification('Your submission will be reviewed.'),
   steps.workflowCommitArticle(),
   steps.checkNotification('New Article Title was committed successfully.'),
-  steps.pause(),
+  {
+    "change title and commit": (client) => {
+      const modalExportSelector = '.apos-workflow-export-modal';
+      const exportSkipSelector = `${modalExportSelector} [data-apos-cancel]`;
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const modalEditArticleSelector = '.apos-pieces-editor';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const editArticleBtnSelector = `${manageTableRowSelector} a`;
+      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
+      const workflowModalBtnSelector =
+        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
+      const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
 
-  // new commit
-  // checknotification
-  // open history model
-  // select old commit
-  // press revert
-  // checknotification
-  // load article
-  // check that title matches commit
+      client.waitForElementVisible(exportSkipSelector);
+      client.click(exportSkipSelector);
+      client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(manageTableRowSelector, () => {
+        console.log('visible')
+        client.pause(1200);
+        client.click(editArticleBtnSelector);
+        console.log('clicked')
+        client.pause()
+      });
+      client.waitForElementVisible(modalEditArticleSelector);
+      //client.waitForElementVisible(controlSelector);
+    }
+  },
   {
     'export the article to all other locales.': (client) => {
       const modalExportSelector = '.apos-workflow-export-modal';

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -41,23 +41,36 @@ module.exports = Object.assign(
       const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
       const editTitleField = `${editModalSelector} input[name=title]`;
       const saveBtnSelector = '[data-apos-save]';
+      const commitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-commit]`;
+      const noPreviewSelector = '.apos-workflow-no-preview';
+      const notificationSelector = '.apos-notification-message';
+      const modalCommitSelector = '.apos-workflow-commit-modal';
+      const aposCommitBtnSelector = `${modalCommitSelector} [data-apos-save]`;
 
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
       client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
-      client.waitForElementVisible(manageTableRowSelector, () => {
-      client.pause(1200);
+      client.waitForElementVisible(manageTableRowSelector);
       client.click(editArticleBtnSelector);
       client.waitForElementVisible(editModalSelector);
       client.clearValue(editTitleField);
       client.setValue(editTitleField, 'Article Title 1');
       client.click(saveBtnSelector);
       client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(editModalSelector);
+      client.waitForElementNotPresent(notificationSelector);
       client.click(editArticleBtnSelector);
-        client.pause()
-      });
-      //client.waitForElementVisible(controlSelector);
+      client.waitForElementVisible(modalEditArticleSelector);
+      client.click(workflowModalBtnSelector);
+      client.waitForElementVisible(commitWorkflowBtnSelector);
+      client.click(commitWorkflowBtnSelector);
+      client.waitForElementVisible(noPreviewSelector);
+      client.expect.element(noPreviewSelector).text.to.equal('No preview available.');
+      client.waitForElementVisible(aposCommitBtnSelector);
+      client.pause(200);
+      client.click(aposCommitBtnSelector);
+      client.pause();
     }
   },
   {

--- a/tests/scenarios/article.spec.js
+++ b/tests/scenarios/article.spec.js
@@ -40,6 +40,7 @@ module.exports = Object.assign(
       const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
       const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
       const editTitleField = `${editModalSelector} input[name=title]`;
+      const saveBtnSelector = '[data-apos-save]';
 
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
@@ -51,6 +52,7 @@ module.exports = Object.assign(
         client.waitForElementVisible(editModalSelector);
         client.clearValue(editTitleField);
         client.setValue(editTitleField, 'Article Title 1');
+        client.click(saveBtnSelector);
         client.pause()
       });
       //client.waitForElementVisible(controlSelector);

--- a/tests/scenarios/revert.spec.js
+++ b/tests/scenarios/revert.spec.js
@@ -14,7 +14,7 @@ module.exports = Object.assign(
       client.end(() => {
         this._server.stop(done);
       });
-    },
+    }
   },
   steps.main(),
   steps.login(),
@@ -35,7 +35,6 @@ module.exports = Object.assign(
       const editArticleBtnSelector = `${manageTableRowSelector} a`;
       const workflowModalBtnSelector =
         `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
-      const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
       const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
       const editTitleField = `${editModalSelector} input[name=title]`;
       const saveBtnSelector = '[data-apos-save]';
@@ -44,7 +43,6 @@ module.exports = Object.assign(
       const notificationSelector = '.apos-notification-message';
       const modalCommitSelector = '.apos-workflow-commit-modal';
       const aposCommitBtnSelector = `${modalCommitSelector} [data-apos-save]`;
-      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
 
       // bail out from last commit's export window
       client.waitForElementVisible(exportSkipSelector);
@@ -82,10 +80,9 @@ module.exports = Object.assign(
   },
   {
     'article can be found under "Articles" in draft mode with title: Article Title 1': (client) => {
-      const blogBtnSelector= '[data-apos-admin-bar-item="apostrophe-blog"]';
-      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const blogBtnSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
       const blogTitleSelector = '.apos-manage-apostrophe-blog-title a';
-      const modalBlogSelector = '.apostrophe-blog-manager';
+
       client.keys(client.Keys.ESCAPE);
       client.keys(client.Keys.ESCAPE);
       client.waitForElementVisible(blogBtnSelector);
@@ -99,15 +96,15 @@ module.exports = Object.assign(
       const modalExportSelector = '.apos-workflow-export-modal';
       const modalBlogSelector = '.apostrophe-blog-manager';
       const modalEditArticleSelector = '.apos-pieces-editor';
+      const managerSelector = '.apos-manage-table';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
       const editArticleBtnSelector = `${manageTableRowSelector} a`;
       const workflowModalBtnSelector =
         `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
-      const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
       const notificationSelector = '.apos-notification-container';
-      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
-      const workflowRevertBtnSelector = ('.apos-manage-table tr:last-child td [data-apos-workflow-revert]')
-      // now revert to previous version
+      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`;
+      const workflowRevertBtnSelector = ('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
+
       client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(manageTableRowSelector);
@@ -117,20 +114,18 @@ module.exports = Object.assign(
       client.pause(200);
       client.waitForElementVisible(workflowHistoryBtnSelector);
       client.click(workflowHistoryBtnSelector);
-      client.waitForElementVisible('.apos-manage-table');
+      client.waitForElementVisible(managerSelector);
       client.waitForElementVisible(workflowRevertBtnSelector);
-      // TODO assert there are two rows
       client.click(workflowRevertBtnSelector);
       client.waitForElementNotVisible(notificationSelector);
     }
   },
   {
     'article can be found under "Articles" in draft mode with title: New Article Title': (client) => {
-      const blogBtnSelector= '[data-apos-admin-bar-item="apostrophe-blog"]';
-      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const blogBtnSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
       const blogTitleSelector = '.apos-manage-apostrophe-blog-title a';
-      const modalBlogSelector = '.apostrophe-blog-manager';
       const notificationSelector = '.apos-notification-container';
+
       client.keys(client.Keys.ESCAPE);
       client.keys(client.Keys.ESCAPE);
       client.pause(500);
@@ -143,5 +138,5 @@ module.exports = Object.assign(
       client.waitForElementVisible(blogTitleSelector);
       client.expect.element(blogTitleSelector).text.to.equal('New Article Title');
     }
-  },
+  }
 );

--- a/tests/scenarios/revert.spec.js
+++ b/tests/scenarios/revert.spec.js
@@ -89,7 +89,6 @@ module.exports = Object.assign(
       client.keys(client.Keys.ESCAPE);
       client.keys(client.Keys.ESCAPE);
       client.waitForElementVisible(blogBtnSelector);
-      client.pause(200);
       client.click(blogBtnSelector);
       client.waitForElementVisible(blogTitleSelector);
       client.expect.element(blogTitleSelector).text.to.equal('Article Title 1');
@@ -107,6 +106,7 @@ module.exports = Object.assign(
       const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
       const notificationSelector = '.apos-notification-container';
       const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
+      const workflowRevertBtnSelector = ('.apos-manage-table tr:last-child td [data-apos-workflow-revert]')
       // now revert to previous version
       client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
@@ -114,26 +114,34 @@ module.exports = Object.assign(
       client.click(editArticleBtnSelector);
       client.waitForElementVisible(modalEditArticleSelector);
       client.click(workflowModalBtnSelector);
+      client.pause(200);
       client.waitForElementVisible(workflowHistoryBtnSelector);
       client.click(workflowHistoryBtnSelector);
       client.waitForElementVisible('.apos-manage-table');
-      client.waitForElementVisible('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
+      client.waitForElementVisible(workflowRevertBtnSelector);
       // TODO assert there are two rows
-      client.click('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
-      client.waitForNotElementVisible(notificationSelector);
+      client.click(workflowRevertBtnSelector);
+      client.waitForElementNotVisible(notificationSelector);
     }
   },
   {
-    'article can be found under "Articles" in draft mode with new title': (client) => {
-      const blogBtnSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
-      const modalBlogSelector = '.apostrophe-blog-manager';
+    'article can be found under "Articles" in draft mode with title: New Article Title': (client) => {
+      const blogBtnSelector= '[data-apos-admin-bar-item="apostrophe-blog"]';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const blogTitleSelector = '.apos-manage-apostrophe-blog-title a';
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const notificationSelector = '.apos-notification-container';
       client.keys(client.Keys.ESCAPE);
+      client.keys(client.Keys.ESCAPE);
+      client.pause(500);
+      client.acceptAlert();
+      client.waitForElementVisible(notificationSelector);
+      client.click(notificationSelector);
       client.pause(200);
+      client.waitForElementVisible(blogBtnSelector);
       client.click(blogBtnSelector);
-      client.waitForElementVisible(modalBlogSelector);
-      client.expect.element(manageTableRowSelector).text.to.contain('New Article Title');
-      client.expect.element(manageTableRowSelector).text.to.contain('Published');
+      client.waitForElementVisible(blogTitleSelector);
+      client.expect.element(blogTitleSelector).text.to.equal('New Article Title');
     }
   },
 );

--- a/tests/scenarios/revert.spec.js
+++ b/tests/scenarios/revert.spec.js
@@ -54,6 +54,7 @@ module.exports = Object.assign(
       client.waitForElementNotPresent(modalExportSelector);
       client.waitForElementVisible(modalBlogSelector);
       client.waitForElementVisible(manageTableRowSelector);
+      client.waitForElementVisible(editArticleBtnSelector);
       client.click(editArticleBtnSelector);
       client.waitForElementVisible(editModalSelector);
       client.clearValue(editTitleField);
@@ -77,20 +78,21 @@ module.exports = Object.assign(
       client.waitForElementVisible(exportSkipSelector);
       client.click(exportSkipSelector);
       client.waitForElementNotPresent(notificationSelector);
-      // TODO assert title = Artile Title 1
     }
   },
   {
-    'article can be found under "Articles" in draft mode with new title': (client) => {
-      const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
-      const modalBlogSelector = '.apostrophe-blog-manager';
+    'article can be found under "Articles" in draft mode with title: Article Title 1': (client) => {
+      const blogBtnSelector= '[data-apos-admin-bar-item="apostrophe-blog"]';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const blogTitleSelector = '.apos-manage-apostrophe-blog-title a';
+      const modalBlogSelector = '.apostrophe-blog-manager';
       client.keys(client.Keys.ESCAPE);
-      client.click(blogButtonSelector);
-      client.waitForElementVisible(modalBlogSelector);
-
-      client.expect.element(manageTableRowSelector).text.to.contain('Article Title 1');
-      client.expect.element(manageTableRowSelector).text.to.contain('Published');
+      client.keys(client.Keys.ESCAPE);
+      client.waitForElementVisible(blogBtnSelector);
+      client.pause(200);
+      client.click(blogBtnSelector);
+      client.waitForElementVisible(blogTitleSelector);
+      client.expect.element(blogTitleSelector).text.to.equal('Article Title 1');
     }
   },
   {
@@ -123,13 +125,12 @@ module.exports = Object.assign(
   },
   {
     'article can be found under "Articles" in draft mode with new title': (client) => {
-      const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
+      const blogBtnSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
       const modalBlogSelector = '.apostrophe-blog-manager';
       const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
       client.keys(client.Keys.ESCAPE);
       client.pause(200);
-      client.waitForElementVisible(blogButtonSelector);
-      client.click(blogButtonSelector);
+      client.click(blogBtnSelector);
       client.waitForElementVisible(modalBlogSelector);
       client.expect.element(manageTableRowSelector).text.to.contain('New Article Title');
       client.expect.element(manageTableRowSelector).text.to.contain('Published');

--- a/tests/scenarios/revert.spec.js
+++ b/tests/scenarios/revert.spec.js
@@ -1,0 +1,138 @@
+const server = require('../server');
+const steps = require('../steps');
+
+module.exports = Object.assign(
+  {
+    before: (client, done) => {
+      client.resizeWindow(1200, 800);
+
+      this._server = server.create();
+      this._server.start(done);
+    },
+
+    after: (client, done) => {
+      client.end(() => {
+        this._server.stop(done);
+      });
+    },
+  },
+  steps.main(),
+  steps.login(),
+  steps.switchLocale('en'),
+  steps.switchToDraftMode(),
+  steps.createArticle('New Article Title'),
+  steps.workflowSubmitArticle(),
+  steps.checkNotification('Your submission will be reviewed.'),
+  steps.workflowCommitArticle(),
+  steps.checkNotification('New Article Title was committed successfully.'),
+  {
+    "change title and commit": (client) => {
+      const modalExportSelector = '.apos-workflow-export-modal';
+      const exportSkipSelector = `${modalExportSelector} [data-apos-cancel]`;
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const modalEditArticleSelector = '.apos-pieces-editor';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const editArticleBtnSelector = `${manageTableRowSelector} a`;
+      const workflowModalBtnSelector =
+        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
+      const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
+      const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
+      const editTitleField = `${editModalSelector} input[name=title]`;
+      const saveBtnSelector = '[data-apos-save]';
+      const commitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-commit]`;
+      const noPreviewSelector = '.apos-workflow-no-preview';
+      const notificationSelector = '.apos-notification-message';
+      const modalCommitSelector = '.apos-workflow-commit-modal';
+      const aposCommitBtnSelector = `${modalCommitSelector} [data-apos-save]`;
+      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
+
+      // bail out from last commit's export window
+      client.waitForElementVisible(exportSkipSelector);
+      client.click(exportSkipSelector);
+
+      // edit article and update title
+      client.waitForElementNotPresent(modalExportSelector);
+      client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(manageTableRowSelector);
+      client.click(editArticleBtnSelector);
+      client.waitForElementVisible(editModalSelector);
+      client.clearValue(editTitleField);
+      client.setValue(editTitleField, 'Article Title 1');
+      client.click(saveBtnSelector);
+      client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(editModalSelector);
+      client.waitForElementNotPresent(notificationSelector);
+
+      // commit the updated article
+      client.click(editArticleBtnSelector);
+      client.waitForElementVisible(modalEditArticleSelector);
+      client.click(workflowModalBtnSelector);
+      client.waitForElementVisible(commitWorkflowBtnSelector);
+      client.click(commitWorkflowBtnSelector);
+      client.waitForElementVisible(noPreviewSelector);
+      client.expect.element(noPreviewSelector).text.to.equal('No preview available.');
+      client.waitForElementVisible(aposCommitBtnSelector);
+      client.click(aposCommitBtnSelector);
+      client.waitForElementVisible(modalExportSelector);
+      client.waitForElementVisible(exportSkipSelector);
+      client.click(exportSkipSelector);
+      client.waitForElementNotPresent(notificationSelector);
+      // TODO assert title = Artile Title 1
+    }
+  },
+  {
+    'article can be found under "Articles" in draft mode with new title': (client) => {
+      const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      client.keys(client.Keys.ESCAPE);
+      client.click(blogButtonSelector);
+      client.waitForElementVisible(modalBlogSelector);
+
+      client.expect.element(manageTableRowSelector).text.to.contain('Article Title 1');
+      client.expect.element(manageTableRowSelector).text.to.contain('Published');
+    }
+  },
+  {
+    'revert to initial version': (client) => {
+      const modalExportSelector = '.apos-workflow-export-modal';
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const modalEditArticleSelector = '.apos-pieces-editor';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const editArticleBtnSelector = `${manageTableRowSelector} a`;
+      const workflowModalBtnSelector =
+        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
+      const editModalSelector = `${modalEditArticleSelector} .apos-schema-group-inner`;
+      const notificationSelector = '.apos-notification-container';
+      const workflowHistoryBtnSelector = `[data-apos-dropdown-name=workflow] [data-apos-workflow-history]`
+      // now revert to previous version
+      client.waitForElementNotPresent(modalExportSelector);
+      client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(manageTableRowSelector);
+      client.click(editArticleBtnSelector);
+      client.waitForElementVisible(modalEditArticleSelector);
+      client.click(workflowModalBtnSelector);
+      client.waitForElementVisible(workflowHistoryBtnSelector);
+      client.click(workflowHistoryBtnSelector);
+      client.waitForElementVisible('.apos-manage-table');
+      client.waitForElementVisible('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
+      // TODO assert there are two rows
+      client.click('.apos-manage-table tr:last-child td [data-apos-workflow-revert]');
+      client.waitForNotElementVisible(notificationSelector);
+    }
+  },
+  {
+    'article can be found under "Articles" in draft mode with new title': (client) => {
+      const blogButtonSelector = '[data-apos-admin-bar-item="apostrophe-blog"]';
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      client.keys(client.Keys.ESCAPE);
+      client.pause(200);
+      client.waitForElementVisible(blogButtonSelector);
+      client.click(blogButtonSelector);
+      client.waitForElementVisible(modalBlogSelector);
+      client.expect.element(manageTableRowSelector).text.to.contain('New Article Title');
+      client.expect.element(manageTableRowSelector).text.to.contain('Published');
+    }
+  },
+);

--- a/tests/steps/index.js
+++ b/tests/steps/index.js
@@ -24,4 +24,7 @@ module.exports = {
   makeIncognitoRequestByRelativeUrl: require('./makeIncognitoRequestByRelativeUrl'),
   openAdminBar: require('./openAdminBar'),
   openContextMenu: require('./openContextMenu'),
+  workflowSubmitArticle: require('./workflowSubmitArticle'),
+  workflowCommitArticle: require('./workflowCommitArticle'),
+  pause: require('./pause'),
 };

--- a/tests/steps/openHistoryModal.js
+++ b/tests/steps/openHistoryModal.js
@@ -1,0 +1,27 @@
+let counter = 0;
+
+module.exports = () => {
+  counter++;
+
+  return {
+    [`[${counter}] open admin bar`]: method,
+  };
+};
+module.exports.method = method;
+
+function method(client) {
+  const btnMenuSelector = '[data-apos-actionable=data-apos-admin-bar]';
+  const openedMenuSelector = '.apos-admin-bar.apos-active';
+
+  client.execute(function(a) {
+    $("[data-apos-actionable=data-apos-admin-bar]").click();
+
+    setTimeout(function() {
+      if ($(".apos-admin-bar.apos-active").length === 0) {
+        $("[data-apos-actionable=data-apos-admin-bar]").click();
+      }
+    }, 5000);
+  });
+
+  client.waitForElementPresent(openedMenuSelector);
+}

--- a/tests/steps/pause.js
+++ b/tests/steps/pause.js
@@ -1,0 +1,11 @@
+let counter = 0;
+
+module.exports = () => {
+  counter++;
+
+  return {
+    [`[${counter}] pause`]: function(client) {
+      client.pause();
+    }
+  };
+};

--- a/tests/steps/workflowCommitArticle.js
+++ b/tests/steps/workflowCommitArticle.js
@@ -1,0 +1,39 @@
+let counter = 0;
+
+module.exports = () => {
+  counter++;
+
+ return {
+    [`[{$counter}] reopen the article. Commit the article.`]: (client) => {
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const modalEditArticleSelector = '.apos-pieces-editor';
+      const modalCommitSelector = '.apos-workflow-commit-modal';
+      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const editArticleBtnSelector = `${manageTableRowSelector} a`;
+      const workflowModalBtnSelector =
+        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
+      const commitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-commit]`;
+      const noPreviewSelector = '.apos-workflow-no-preview';
+      const saveBtnSelector = `${modalCommitSelector} [data-apos-save]`;
+      const notificationSelector = '.apos-notification-message';
+
+      client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(manageTableRowSelector);
+      client.click(editArticleBtnSelector);
+      client.waitForElementVisible(modalEditArticleSelector);
+      client.waitForElementVisible(controlSelector);
+      client.pause(200);
+      client.click(workflowModalBtnSelector);
+      client.useCss();
+      client.waitForElementVisible(commitWorkflowBtnSelector);
+      client.click(commitWorkflowBtnSelector);
+      client.waitForElementVisible(noPreviewSelector);
+
+      client.expect.element(noPreviewSelector).text.to.equal('No preview available.');
+
+      client.waitForElementNotPresent(notificationSelector);
+      client.click(saveBtnSelector);
+    }
+  };
+};

--- a/tests/steps/workflowSubmitArticle.js
+++ b/tests/steps/workflowSubmitArticle.js
@@ -1,0 +1,30 @@
+let counter = 0;
+
+module.exports = () => {
+  counter++;
+
+ return {
+    [`[${counter}] submit the article via the "Workflow" menu in the dialog box`]: (client) => {
+      const modalBlogSelector = '.apostrophe-blog-manager';
+      const modalEditArticleSelector = '.apos-pieces-editor';
+      const manageTableRowSelector = '.apos-manage-table tr[data-piece]';
+      const editArticleBtnSelector = `${manageTableRowSelector} a`;
+      const controlSelector = `${modalEditArticleSelector} .apos-modal-controls .apos-dropdown`;
+      const workflowModalBtnSelector =
+        `${modalEditArticleSelector} [data-apos-dropdown-name="workflow"]`;
+      const submitWorkflowBtnSelector = `${modalEditArticleSelector} [data-apos-workflow-submit]`;
+
+      client.waitForElementVisible(modalBlogSelector);
+      client.waitForElementVisible(manageTableRowSelector);
+      client.click(editArticleBtnSelector);
+      client.waitForElementVisible(modalEditArticleSelector);
+      client.waitForElementVisible(controlSelector);
+      client.pause(1000);
+      client.click(workflowModalBtnSelector);
+      client.useCss();
+      client.waitForElementVisible(submitWorkflowBtnSelector);
+      client.click(submitWorkflowBtnSelector);
+      client.waitForElementNotPresent(modalEditArticleSelector);
+    }
+  };
+};


### PR DESCRIPTION
For workflow revert implementation see: https://github.com/apostrophecms/apostrophe-workflow/pull/172

The PR includes a convenience script definition for `npm run revert-local` which will run just the appropriate nightwatch scenario. This can used for qa and removed as you see fit.

