### PR TITLE
Reproduce issue 178 from apostrophe-workflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,6 +102,10 @@ function run(config, ready) {
         'as-helpers': {},
         'as-two-column-block-widgets': {},
 
+        // Issue Demo Widgets
+        'fw-lazy-image-widgets': {},
+        'issue-demo-widgets': {},
+
         'apostrophe-workflow': {
           alias: 'workflow',
           locales: [

--- a/lib/modules/apostrophe-pages/views/pages/home.html
+++ b/lib/modules/apostrophe-pages/views/pages/home.html
@@ -27,6 +27,15 @@
             }
         }) }}
       </div>
+      <div class="demo-pageheader" id="issue-demo">
+          {{
+            apos.area(data.page, 'issueDemo', {
+              widgets: {
+                'issue-demo': {}
+              } 
+            })
+          }}
+        </div>
     </div>
     <div class="demo-workspaces-marquee"></div>
     <div class="block content--bottom">

--- a/lib/modules/fw-lazy-image-widgets/index.js
+++ b/lib/modules/fw-lazy-image-widgets/index.js
@@ -1,0 +1,77 @@
+module.exports = {
+  extend: 'apostrophe-widgets',
+  label: 'Image (Lazily loaded)',
+  addFields: [
+    {
+      name: 'image_1x',
+      type: 'singleton',
+      label: 'Image - 1x',
+      widgetType: 'apostrophe-images'
+    },
+    {
+      name: 'image_2x',
+      type: 'singleton',
+      label: 'Image - 2x',
+      widgetType: 'apostrophe-images'
+    },
+    {
+      name: 'title',
+      type: 'string',
+      label: 'Title (text that appears in the browser tooltip)'
+    },
+    {
+      name: 'alt',
+      type: 'string',
+      label: 'Alt text for screenreaders'
+    }
+  ],
+  construct: function (self, options) {
+    self.addHelpers({
+      getSrcObject: function (image1x, image2x, apos) {
+        let obj = {
+          src: '',
+          placeholder_src: '',
+          srcset: '',
+          placeholder_srcset: ''
+        }
+        try {
+          const img1x = image1x.items[0]._pieces[0].item.attachment
+          obj = {
+            src: apos.attachments.url(img1x),
+            placeholder_src: apos.attachments.url(img1x, { size: 'one-sixth' }),
+            srcset: '',
+            placeholder_srcset: ''
+          }
+        } catch (e) {
+          console.error('Error caught in fw-lazy-image - 1x getSrcObject helper. Message: ' + e.message)
+          console.error('JSON Dump')
+          console.error('image1x: ' + JSON.stringify(image1x))
+          return {
+            src: '',
+            placeholder_src: '',
+            srcset: '',
+            placeholder_srcset: ''
+          }
+        }
+        try {
+          if (image2x.items.length > 0) {
+            const img2x = image2x.items[0]._pieces[0].item.attachment
+            obj.srcset = apos.attachments.url(img2x) + ' 2x'
+            obj.placeholder_srcset = apos.attachments.url(img2x, { size: 'one-sixth' }) + ' 2x'
+          }
+        } catch (e) {
+          console.error('Error caught in fw-lazy-image - 2x getSrcObject helper. Message: ' + e.message)
+          console.error('JSON Dump')
+          console.error('image2x: ' + JSON.stringify(image2x))
+          return {
+            src: '',
+            placeholder_src: '',
+            srcset: '',
+            placeholder_srcset: ''
+          }
+        }
+        return obj;
+      }
+    })
+  }
+}

--- a/lib/modules/fw-lazy-image-widgets/views/widget.html
+++ b/lib/modules/fw-lazy-image-widgets/views/widget.html
@@ -1,0 +1,5 @@
+{% set obj = module.getSrcObject(data.widget.image_1x, data.widget.image_2x, apos) %}
+
+<img class="lazy-image {{ data.options.image_classes }}" data-src="{{ obj.src }}" data-srcset="{{ obj.srcset }}" src="{{ obj.placeholder_src }}" srcset="{{ obj.placeholder_srcset }}"
+/>
+<img class="original-image fadeIn {{ data.options.image_classes }}" alt="{{ data.widget.alt }}" title="{{ data.widget.title }}" src="" srcset=""/>

--- a/lib/modules/issue-demo-widgets/index.js
+++ b/lib/modules/issue-demo-widgets/index.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extend: 'apostrophe-widgets',
+  label: 'Sample Array Schema',
+  addFields: [
+    {
+      name: 'content_array',
+      type: 'array',
+      label: 'Array of content items',
+      schema: [{
+        name: 'image',
+        label: 'Logo Image',
+        type: 'singleton',
+        widgetType: 'fw-lazy-image'
+      }]
+
+    }
+  ],
+  construct: function (self, options) {
+  }
+}
+

--- a/lib/modules/issue-demo-widgets/views/widget.html
+++ b/lib/modules/issue-demo-widgets/views/widget.html
@@ -1,0 +1,3 @@
+{% for item in data.widget.content_array %}
+  {{ apos.singleton(item, 'image', 'fw-lazy-image', {}) }}
+{% endfor %}


### PR DESCRIPTION
Try adding a couple of items in an instance of the ‘issue-demo’ widget.
Once you commit the change, you should be able to see the images in
draft mode, but you won’t be able to see the images in live mode.