### PR TITLE
verify that minify is not broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "e2e-local": "VISUAL_ENV=local tests/run-all",
     "test-with-visual-diff": "( VISUAL_ENV=local node tests/screenshot-previous.js && VISUAL_ENV=local tests/run-all && node visual-regression-test.js )",
     "minify-test": "test/minify",
-    "test": "npm run minify-test && ( npm run e2e-local ) && ( DISABLE_ANON_SESSION=1 NO_REPLICATE=1 npm run e2e-local )"
+    "test": "rm -rf node_modules && npm install && npm run minify-test && ( npm run e2e-local ) && ( DISABLE_ANON_SESSION=1 NO_REPLICATE=1 npm run e2e-local )"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "e2e-local": "VISUAL_ENV=local tests/run-all",
     "test-with-visual-diff": "( VISUAL_ENV=local node tests/screenshot-previous.js && VISUAL_ENV=local tests/run-all && node visual-regression-test.js )",
     "minify-test": "test/minify",
-    "test": "rm -rf node_modules && npm install && npm run minify-test && ( npm run e2e-local ) && ( DISABLE_ANON_SESSION=1 NO_REPLICATE=1 npm run e2e-local )"
+    "test": "rm -f package-lock.json && rm -rf node_modules && npm install && npm run minify-test && ( npm run e2e-local ) && ( DISABLE_ANON_SESSION=1 NO_REPLICATE=1 npm run e2e-local )"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "restore": "mongorestore --noIndexRestore mongodump/ --drop",
     "e2e-local": "VISUAL_ENV=local tests/run-all",
     "test-with-visual-diff": "( VISUAL_ENV=local node tests/screenshot-previous.js && VISUAL_ENV=local tests/run-all && node visual-regression-test.js )",
-    "test": "( npm run e2e-local ) && ( DISABLE_ANON_SESSION=1 NO_REPLICATE=1 npm run e2e-local )"
+    "minify-test": "test/minify",
+    "test": "npm run minify-test && ( npm run e2e-local ) && ( DISABLE_ANON_SESSION=1 NO_REPLICATE=1 npm run e2e-local )"
   },
   "repository": {
     "type": "git",

--- a/test/minify
+++ b/test/minify
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Make sure the webserver process dies when we exit
+trap 'kill $(jobs -p)' EXIT
+
+# Create an asset bundle the recommended way
+APOS_BUNDLE=1 node app apostrophe:generation || exit 1
+# Fire up the site using that bundle's assets
+APOS_BUNDLE=1 node app &
+sleep 10
+# Verify we can get the home page
+wget http://localhost:3000 -O /tmp/$$.html || exit 1
+# http://localhost:3000/uploads/assets/ck199jeiq00013quk6zgkmbd2/apos-minified/anon-ck199jeiq00013quk6zgkmbd2.css
+if ! grep -P "uploads/assets/.*/apos-minified/anon-.*.css" /tmp/$$.html ; then
+  echo "Output does not load anon CSS from bundle"
+  exit 1
+fi
+LINE=`grep -P "uploads/assets/.*/apos-minified/anon-.*.css" /tmp/$$.html`
+MATCH=`echo $LINE | grep -o -P 'http[^"]+'` 
+wget $MATCH -O /dev/null || exit 1
+echo "Good CSS from bundle"
+
+if ! grep -P "uploads/assets/.*/apos-minified/anon-.*.js" /tmp/$$.html ; then
+  echo "Output does not load anon JS from bundle"
+  exit 1
+fi
+LINE=`grep -P "uploads/assets/.*/apos-minified/anon-.*.js" /tmp/$$.html`
+echo "Line is $LINE"
+MATCH=`echo $LINE | grep -o -P 'http[^"]+'` 
+wget $MATCH -O /dev/null || exit 1
+echo "Good JS from bundle"
+
+# Don't litter or we'll break dev assets
+rm data/generation || exit 1
+rm -rf public/modules || exit 1
+

--- a/test/minify
+++ b/test/minify
@@ -10,27 +10,26 @@ APOS_BUNDLE=1 node app &
 sleep 10
 # Verify we can get the home page
 wget http://localhost:3000 -O /tmp/$$.html || exit 1
-# http://localhost:3000/uploads/assets/ck199jeiq00013quk6zgkmbd2/apos-minified/anon-ck199jeiq00013quk6zgkmbd2.css
-if ! grep -P "uploads/assets/.*/apos-minified/anon-.*.css" /tmp/$$.html ; then
+if ! egrep "uploads/assets/.*/apos-minified/anon-.*.css" /tmp/$$.html ; then
   echo "Output does not load anon CSS from bundle"
   exit 1
 fi
-LINE=`grep -P "uploads/assets/.*/apos-minified/anon-.*.css" /tmp/$$.html`
-MATCH=`echo $LINE | grep -o -P 'http[^"]+'` 
+LINE=`egrep "uploads/assets/.*/apos-minified/anon-.*.css" /tmp/$$.html`
+MATCH=`echo $LINE | egrep -o 'http[^"]+'` 
 wget $MATCH -O /dev/null || exit 1
 echo "Good CSS from bundle"
 
-if ! grep -P "uploads/assets/.*/apos-minified/anon-.*.js" /tmp/$$.html ; then
+if ! egrep "uploads/assets/.*/apos-minified/anon-.*.js" /tmp/$$.html ; then
   echo "Output does not load anon JS from bundle"
   exit 1
 fi
-LINE=`grep -P "uploads/assets/.*/apos-minified/anon-.*.js" /tmp/$$.html`
+LINE=`egrep "uploads/assets/.*/apos-minified/anon-.*.js" /tmp/$$.html`
 echo "Line is $LINE"
-MATCH=`echo $LINE | grep -o -P 'http[^"]+'` 
+MATCH=`echo $LINE | egrep -o 'http[^"]+'` 
 wget $MATCH -O /dev/null || exit 1
 echo "Good JS from bundle"
 
 # Don't litter or we'll break dev assets
 rm data/generation || exit 1
 rm -rf public/modules || exit 1
-
+rm /tmp/$$.html


### PR DESCRIPTION
Prevent uglifyjs "oops this module does not work in production with minify" errors in future by doing a full minified APOS_BUNDLE=1 build, then verifying that the site comes up and we can grab the relevant CSS and JS and that they are served from the bundle.

This will catch errors like ES6 leaking into our frontend code in 2.x in the core modules, all of which are present in apostrophe-enterprise-testbed.

However it is important that I change my regression test practices so I'm doing a full npm install (not just using what I have locally npm linked), and/or get this thing running on a CI server again, which I would love to do if we ever have a goldang minit to address the version conflicts between chrome and chromedriver on those services, etc.